### PR TITLE
Re-organise somatic paired workflow outputs

### DIFF
--- a/janis_pipelines/wgs_somatic/wgssomatic_variantsonly.py
+++ b/janis_pipelines/wgs_somatic/wgssomatic_variantsonly.py
@@ -120,6 +120,7 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
             "out_gridss_assembly",
             source=self.vc_gridss.assembly,
             output_folder=[
+                "sv",
                 "gridss",
             ],
             output_name=StringFormatter(
@@ -133,6 +134,7 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
             "out_variants_gridss",
             source=self.vc_gridss.out,
             output_folder=[
+                "sv",
                 "gridss",
             ],
             output_name=StringFormatter(
@@ -165,7 +167,10 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
         self.output(
             "out_facets_summary",
             source=self.vc_facets.out_summary,
-            output_folder="facets",
+            output_folder=[
+                "cnv",
+                "facets",
+            ],
             output_name=StringFormatter(
                 "{tumour}--{normal}.txt",
                 tumour=self.tumor_name,
@@ -175,7 +180,10 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
         self.output(
             "out_facets_purity_png",
             source=self.vc_facets.out_purity_png,
-            output_folder="facets",
+            output_folder=[
+                "cnv",
+                "facets",
+            ],
             output_name=StringFormatter(
                 "{tumour}--{normal}_purity.png",
                 tumour=self.tumor_name,
@@ -185,7 +193,10 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
         self.output(
             "out_facets_purity_seg",
             source=self.vc_facets.out_purity_seg,
-            output_folder="facets",
+            output_folder=[
+                "cnv",
+                "facets",
+            ],
             output_name=StringFormatter(
                 "{tumour}--{normal}_purity.seg",
                 tumour=self.tumor_name,
@@ -195,7 +206,10 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
         self.output(
             "out_facets_purity_rds",
             source=self.vc_facets.out_purity_rds,
-            output_folder="facets",
+            output_folder=[
+                "cnv",
+                "facets",
+            ],
             output_name=StringFormatter(
                 "{tumour}--{normal}_purity.rds",
                 tumour=self.tumor_name,
@@ -205,7 +219,10 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
         self.output(
             "out_facets_hisens_png",
             source=self.vc_facets.out_hisens_png,
-            output_folder="facets",
+            output_folder=[
+                "cnv",
+                "facets",
+            ],
             output_name=StringFormatter(
                 "{tumour}--{normal}_hisens.png",
                 tumour=self.tumor_name,
@@ -215,7 +232,10 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
         self.output(
             "out_facets_hisens_seg",
             source=self.vc_facets.out_hisens_seg,
-            output_folder="facets",
+            output_folder=[
+                "cnv",
+                "facets",
+            ],
             output_name=StringFormatter(
                 "{tumour}--{normal}_hisens.seg",
                 tumour=self.tumor_name,
@@ -225,7 +245,10 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
         self.output(
             "out_facets_hisens_rds",
             source=self.vc_facets.out_hisens_rds,
-            output_folder="facets",
+            output_folder=[
+                "cnv",
+                "facets",
+            ],
             output_name=StringFormatter(
                 "{tumour}--{normal}_hisens.rds",
                 tumour=self.tumor_name,
@@ -235,7 +258,10 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
         self.output(
             "out_facets_arm_level",
             source=self.vc_facets.out_arm_level,
-            output_folder="facets",
+            output_folder=[
+                "cnv",
+                "facets",
+            ],
             output_name=StringFormatter(
                 "{tumour}--{normal}.arm_level.txt",
                 tumour=self.tumor_name,
@@ -245,7 +271,10 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
         self.output(
             "out_facets_gene_level",
             source=self.vc_facets.out_gene_level,
-            output_folder="facets",
+            output_folder=[
+                "cnv",
+                "facets",
+            ],
             output_name=StringFormatter(
                 "{tumour}--{normal}.gene_level.txt",
                 tumour=self.tumor_name,
@@ -255,7 +284,10 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
         self.output(
             "out_facets_qc",
             source=self.vc_facets.out_qc,
-            output_folder="facets",
+            output_folder=[
+                "cnv",
+                "facets",
+            ],
             output_name=StringFormatter(
                 "{tumour}--{normal}.qc.txt",
                 tumour=self.tumor_name,
@@ -342,7 +374,7 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
             doc="Merged variants from the GATK caller",
         )
         self.output(
-            "out_variants_split",
+            "out_variants_gakt_split",
             source=self.vc_gatk.out,
             output_folder=[
                 "vcf",
@@ -378,6 +410,20 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
                 normal_name=self.normal_name,
             ),
             doc="Variants from the Strelka variant caller",
+        )
+        self.output(
+            "out_variants_manta",
+            source=self.vc_strelka.sv,
+            output_folder=[
+                "sv",
+                "manta",
+            ],
+            output_name=StringFormatter(
+                "{tumor_name}--{normal_name}_manta",
+                tumor_name=self.tumor_name,
+                normal_name=self.normal_name,
+            ),
+            doc="SV variants from the Manta caller",
         )
 
     def add_vardict_variantcaller(self, normal_bam_source, tumor_bam_source):

--- a/janis_pipelines/wgs_somatic/wgssomatic_variantsonly.py
+++ b/janis_pipelines/wgs_somatic/wgssomatic_variantsonly.py
@@ -412,8 +412,8 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
             doc="Variants from the Strelka variant caller",
         )
         self.output(
-            "out_variants_manta",
-            source=self.vc_strelka.sv,
+            "out_variants_manta_somatic",
+            source=self.vc_strelka.tumor_sv,
             output_folder=[
                 "sv",
                 "manta",

--- a/janis_pipelines/wgs_somatic/wgssomatic_variantsonly.py
+++ b/janis_pipelines/wgs_somatic/wgssomatic_variantsonly.py
@@ -172,7 +172,7 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
                 "facets",
             ],
             output_name=StringFormatter(
-                "{tumour}--{normal}.txt",
+                "{tumour}--{normal}",
                 tumour=self.tumor_name,
                 normal=self.normal_name,
             ),
@@ -185,7 +185,7 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
                 "facets",
             ],
             output_name=StringFormatter(
-                "{tumour}--{normal}_purity.png",
+                "{tumour}--{normal}_purity",
                 tumour=self.tumor_name,
                 normal=self.normal_name,
             ),
@@ -198,7 +198,7 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
                 "facets",
             ],
             output_name=StringFormatter(
-                "{tumour}--{normal}_purity.seg",
+                "{tumour}--{normal}_purity",
                 tumour=self.tumor_name,
                 normal=self.normal_name,
             ),
@@ -211,7 +211,7 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
                 "facets",
             ],
             output_name=StringFormatter(
-                "{tumour}--{normal}_purity.rds",
+                "{tumour}--{normal}_purity",
                 tumour=self.tumor_name,
                 normal=self.normal_name,
             ),
@@ -224,7 +224,7 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
                 "facets",
             ],
             output_name=StringFormatter(
-                "{tumour}--{normal}_hisens.png",
+                "{tumour}--{normal}_hisens",
                 tumour=self.tumor_name,
                 normal=self.normal_name,
             ),
@@ -237,7 +237,7 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
                 "facets",
             ],
             output_name=StringFormatter(
-                "{tumour}--{normal}_hisens.seg",
+                "{tumour}--{normal}_hisens",
                 tumour=self.tumor_name,
                 normal=self.normal_name,
             ),
@@ -250,7 +250,7 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
                 "facets",
             ],
             output_name=StringFormatter(
-                "{tumour}--{normal}_hisens.rds",
+                "{tumour}--{normal}_hisens",
                 tumour=self.tumor_name,
                 normal=self.normal_name,
             ),
@@ -263,7 +263,7 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
                 "facets",
             ],
             output_name=StringFormatter(
-                "{tumour}--{normal}.arm_level.txt",
+                "{tumour}--{normal}.arm_level",
                 tumour=self.tumor_name,
                 normal=self.normal_name,
             ),
@@ -276,7 +276,7 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
                 "facets",
             ],
             output_name=StringFormatter(
-                "{tumour}--{normal}.gene_level.txt",
+                "{tumour}--{normal}.gene_level",
                 tumour=self.tumor_name,
                 normal=self.normal_name,
             ),
@@ -289,7 +289,7 @@ class WGSSomaticMultiCallersVariantsOnly(WGSSomaticGATKVariantsOnly):
                 "facets",
             ],
             output_name=StringFormatter(
-                "{tumour}--{normal}.qc.txt",
+                "{tumour}--{normal}.qc",
                 tumour=self.tumor_name,
                 normal=self.normal_name,
             ),


### PR DESCRIPTION
Output folder restructure:
 - Add "sv" folder, and save GRIDSS and Manta output
 - Add "cnv" folder, and remove double extension in facets output files
 - Rename id for better description: "out_variants_split" to "out_variants_gakt_split" 